### PR TITLE
move io event handler to app.ready

### DIFF
--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -8,11 +8,15 @@ const app = fastify({ logger: true })
 app.register(socketio)
 
 app.get('/', async (req, reply) => {
-  app.io.on('connect', () => console.info('Socket connected!'))
-
   const data = await readFile(join(__dirname, '..', 'index.html'))
   reply.header('content-type', 'text/html; charset=utf-8')
   reply.send(data)
+})
+
+app.ready(err => {
+  if (err) throw err
+
+  app.io.on('connect', (socket) => console.info('Socket connected!', socket.id))
 })
 
 app.listen(3000)

--- a/examples/typescript/server.ts
+++ b/examples/typescript/server.ts
@@ -8,11 +8,15 @@ const app = fastify({ logger: true })
 app.register(socketioServer)
 
 app.get('/', async (req, reply) => {
-  app.io.on('connect', () => console.info('Socket connected!'))
-
   const data = await readFile(join(__dirname, '..', 'index.html'))
   reply.header('content-type', 'text/html; charset=utf-8')
   reply.send(data)
+})
+
+app.ready(err => {
+  if (err) throw err
+
+  app.io.on('connect', (socket) => console.info('Socket connected!', socket.id))
 })
 
 app.listen(3000)


### PR DESCRIPTION
Making example a bit more noob-friendly:
1) Moving the event handler to `app.ready` to avoid creation of multiple event handlers when refreshing client page.
2) Adding socket parameter to event handler