### PR TITLE
Fix index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginAsync, FastifyServerOptions } from 'fastify'
+import { FastifyPluginAsync } from 'fastify'
 import * as SocketIO from 'socket.io'
 
 declare module 'fastify' {
@@ -7,5 +7,5 @@ declare module 'fastify' {
   }
 }
 
-export const socketioServer: FastifyPluginAsync<Partial<FastifyServerOptions>>
+export const socketioServer: FastifyPluginAsync<Partial<SocketIO.ServerOptions>>
 export default socketioServer

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
-import { FastifyPlugin } from 'fastify'
-import { ServerOptions } from 'socket.io'
+import { FastifyPluginAsync, FastifyServerOptions } from 'fastify'
+import * as SocketIO from 'socket.io'
 
 declare module 'fastify' {
-  export interface FastifyInstance {
+  interface FastifyInstance {
     io: SocketIO.Server
   }
 }
 
-declare const socketioServer: FastifyPlugin<Partial<ServerOptions>>
+export const socketioServer: FastifyPluginAsync<Partial<FastifyServerOptions>>
 export default socketioServer

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 import { FastifyPluginAsync } from 'fastify'
-import * as SocketIO from 'socket.io'
+import { Server, ServerOptions } from 'socket.io'
 
 declare module 'fastify' {
   interface FastifyInstance {
-    io: SocketIO.Server
+    io: Server
   }
 }
 
-export const socketioServer: FastifyPluginAsync<Partial<SocketIO.ServerOptions>>
+export const socketioServer: FastifyPluginAsync<Partial<ServerOptions>>
 export default socketioServer

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,26 +1,30 @@
 import fastify from 'fastify'
 import socketioServer from '..'
 import { expectType, expectAssignable } from 'tsd'
-import { ServerOptions } from 'socket.io'
+import { Server, ServerOptions } from 'socket.io'
 
-try {
-  const app = fastify()
+const test = async () => {
+  try {
+    const app = fastify()
 
-  await app.ready()
+    await app.ready()
 
-  await app.register(socketioServer)
+    await app.register(socketioServer)
 
-  app.io.emit('test')
+    app.io.emit('test')
 
-  expectType<SocketIO.Server>(app.io)
+    expectType<Server>(app.io)
 
-  expectAssignable<Partial<ServerOptions>>({
-    path: '/test',
-    serveClient: false,
-    pingInterval: 10000,
-    pingTimeout: 5000,
-    cookie: false
-  })
-} catch (err) {
-  console.error(err)
+    expectAssignable<Partial<ServerOptions>>({
+      path: '/test',
+      serveClient: false,
+      pingInterval: 10000,
+      pingTimeout: 5000,
+      cookie: false
+    })
+  } catch (err) {
+    console.error(err)
+  }
 }
+
+test();

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -3,28 +3,24 @@ import socketioServer from '..'
 import { expectType, expectAssignable } from 'tsd'
 import { Server, ServerOptions } from 'socket.io'
 
-const test = async (): Promise<void> => {
-  try {
-    const app = fastify()
+try {
+  const app = fastify()
 
-    await app.ready()
+  await app.ready()
 
-    await app.register(socketioServer)
+  await app.register(socketioServer)
 
-    app.io.emit('test')
+  app.io.emit('test')
 
-    expectType<Server>(app.io)
+  expectType<Server>(app.io)
 
-    expectAssignable<Partial<ServerOptions>>({
-      path: '/test',
-      serveClient: false,
-      pingInterval: 10000,
-      pingTimeout: 5000,
-      cookie: false
-    })
-  } catch (err) {
-    console.error(err)
-  }
+  expectAssignable<Partial<ServerOptions>>({
+    path: '/test',
+    serveClient: false,
+    pingInterval: 10000,
+    pingTimeout: 5000,
+    cookie: false
+  })
+} catch (err) {
+  console.error(err)
 }
-
-await test()

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -3,7 +3,7 @@ import socketioServer from '..'
 import { expectType, expectAssignable } from 'tsd'
 import { Server, ServerOptions } from 'socket.io'
 
-const test = async () => {
+const test = async (): Promise<void> => {
   try {
     const app = fastify()
 
@@ -27,4 +27,4 @@ const test = async () => {
   }
 }
 
-test();
+await test()


### PR DESCRIPTION
Current version's index.d.ts is broken so you can't get type information of `FastifyInstance.io`.
I fixed it. Please merge and release new version to npm.