### PR TITLE
Fix deprecated method app.listen(PORT) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fastify.get('/', (req, reply) => {
   fastify.io.emit('hello')
 })
 
-fastify.listen(3000)
+fastify.listen({ port: 3000 })
 ```
 For more details see [examples](https://github.com/alemagio/fastify-socket.io/tree/master/examples)
 

--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -19,4 +19,4 @@ app.ready(err => {
   app.io.on('connect', (socket) => console.info('Socket connected!', socket.id))
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })

--- a/examples/typescript-example/server.ts
+++ b/examples/typescript-example/server.ts
@@ -19,4 +19,4 @@ app.ready(err => {
   app.io.on('connection', (socket: any) => console.info('Socket connected!', socket.id))
 })
 
-app.listen(3000)
+app.listen({ port: 3000 })


### PR DESCRIPTION
app.listen(PORT) is deprecated since v.4.0 and will be completely removed in version v.5.0. 

So I replaced it with new method app.listen({ port: PORT }).