### PR TITLE
only signal done when close is actually finished

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ const fastifySocketIO: FastifyPluginAsync<Partial<ServerOptions>> = fp(
   async function (fastify, opts) {
     fastify.decorate("io", new Server(fastify.server, opts));
     fastify.addHook("onClose", (fastify: FastifyInstance, done) => {
-      (fastify as any).io.close();
-      done();
+      (fastify as any).io.close(() => done());
     });
   },
   { fastify: ">=4.x.x", name: "fastify-socket.io" }


### PR DESCRIPTION
## In this PR:

- Bug fix (non-breaking change which fixes an issue)

Make the plugin only signal done when socket.io is actually closed. Otherwise one might end up closing e.g. the Mongo connection the adapters are depending on. Will be even more relevant after https://github.com/socketio/socket.io/pull/4971 has been merged.

## Issues reference:

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/ducktors/crane/pulls) for the same update/change?
* [ ] Have you lint your code with `pnpm lint` locally prior to submission?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran build with `pnpm build` of your changes locally?
* [ ] Have you successfully ran tests with `pnpm test` of your changes locally?
* [ ] Have you commit using [Conventional Commits](https://github.com/ducktors/crane#how-to-commit)?
